### PR TITLE
Adjust TTL via ENV vars. Change collection name for widgets task queue. Delete task after it's done.

### DIFF
--- a/app/placemats/stores/task_queue_config.py
+++ b/app/placemats/stores/task_queue_config.py
@@ -4,4 +4,4 @@ from app.placemats.stores.mongo_client import mongo_db
 
 
 def widgets_task_queue() -> BaseTaskQueue:
-    return MongoTaskQueue(mongo_db()['widgets_task_queue'])
+    return MongoTaskQueue(mongo_db()['widgets_task_queue_v2'])


### PR DESCRIPTION
Changes suggested via email.

Tested changes locally. New collection is made w/ expected TTL (24 hours by default), and tasks are deleted from the queue when completed.